### PR TITLE
Update Server and Node Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.17.0-alpine
+FROM node:14.15.0-alpine
 
 WORKDIR /stremio
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8.17.0-alpine
 
 WORKDIR /stremio
 
-ARG VERSION=4.4.120
+ARG VERSION=4.4.137
 
 RUN apk add --no-cache wget ffmpeg
 RUN wget https://dl.strem.io/four/v${VERSION}/server.js


### PR DESCRIPTION
This PR updates Stremio server to the latest, and also updates Node to v14.15.0 (this is the Node version that is currently used in the official releases)

It's a pretty important server update as we found an ancient bug in the torrent streaming server and fixed it.