### PR TITLE
fix: remove CORS headers conditional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG VERSION=master
 RUN apk add --no-cache wget ffmpeg
 RUN wget http://dl.strem.io/four/${VERSION}/server.js
 RUN wget http://dl.strem.io/four/${VERSION}/stremio.asar
+RUN sed -i 's/if (ok) enginefs.sendCORSHeaders/if (true) enginefs.sendCORSHeaders/g' server.js
 
 VOLUME ["/root/.stremio-server"]
 


### PR DESCRIPTION
This will 'patch' the `if` conditional to always return true to all domains, so the CORS headers will be sent.