### PR TITLE
Added a patch that can be enabled by an ENV variable to force HTTPS for streamServer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14.15.0-alpine
 
-WORKDIR stremio
+WORKDIR /stremio
 
 ARG VERSION=master
 ENV FORCE_HTTPS=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM node:14.15.0-alpine
 
-WORKDIR /stremio
+WORKDIR stremio
 
 ARG VERSION=master
+ENV FORCE_HTTPS=0
 
 RUN apk add --no-cache openssl-dev wget ffmpeg
 RUN wget https://dl.strem.io/four/${VERSION}/server.js
 RUN wget https://dl.strem.io/four/${VERSION}/stremio.asar
+COPY start.sh .
+
+RUN chmod +x start.sh
 
 # apply patch to skip CORS headers verification
 # see: https://github.com/sleeyax/stremio-streaming-server/issues/5
@@ -16,4 +20,4 @@ VOLUME ["/root/.stremio-server"]
 
 EXPOSE 11470
 
-ENTRYPOINT [ "node", "server.js" ]
+ENTRYPOINT ./start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ $FORCE_HTTPS == 1 ]; then
+  echo 'Forcing HTTPS for serverURL.'
+  sed -i "s~var serverUrl = encodeURIComponent( protocol + req.headers.host);~var serverUrl = encodeURIComponent( 'https://' + req.headers.host);~g" server.js
+fi
+
+node server.js


### PR DESCRIPTION
The solution for issue #10 had as a consequence that the `streamServer` within the URL would always be set to http although the container is called via https (via the proxy).

While it's clear why this is happening, since it's proxying after all, it's very tedious and disruptive to the UX. Especially on mobile systems. 

Therefore it's crucial to be able to force the stremServer's protocol to https.